### PR TITLE
change head_EPRSC_ID to trackingCode for tamin prescriptions, in toas…

### DIFF
--- a/apps/drapp/src/components/turning/tutnsList/default.jsx
+++ b/apps/drapp/src/components/turning/tutnsList/default.jsx
@@ -76,7 +76,7 @@ const TurnRow = {
                 trackingCode:
                     turn.prescription &&
                     (turn.prescription?.insuranceType === 'tamin'
-                        ? turn.prescription.tamin_prescription.map(item => item.head_EPRSC_ID)
+                        ? turn.prescription.tamin_prescription.map(item => item.trackingCode)
                         : [turn.prescription.salamat_prescription?.trackingCode]),
                 sequenceNumber: turn.prescription?.salamat_prescription?.sequenceNumber
             }}
@@ -105,7 +105,7 @@ const TurnRow = {
                 provider: turn.insuranceType,
                 trackingCode:
                     turn?.insuranceType === 'tamin'
-                        ? turn.tamin_prescription.map(item => item.head_EPRSC_ID)
+                        ? turn.tamin_prescription.map(item => item.trackingCode)
                         : [turn.salamat_prescription?.trackingCode],
                 sequenceNumber: turn.salamat_prescription?.sequenceNumber
             }}

--- a/apps/drapp/src/pages/drApp/turning/index.jsx
+++ b/apps/drapp/src/pages/drApp/turning/index.jsx
@@ -314,7 +314,7 @@ const Turning = () => {
                                 {prescriptionPendingModal?.insuranceType === 'tamin' &&
                                     prescriptionPendingModal?.[
                                         prescriptionPendingModal?.insuranceType + '_prescriptions'
-                                    ]?.[0]?.head_EPRSC_ID}
+                                    ]?.[0]?.trackingCode}
                                 {''}
                                 با موفقیت ثبت شد.
                                 {'  '}

--- a/apps/drapp/src/pages/drApp/turning/index.jsx
+++ b/apps/drapp/src/pages/drApp/turning/index.jsx
@@ -274,7 +274,7 @@ const Turning = () => {
                     {prescriptionSuccessedModal?.insuranceType === 'tamin' &&
                         prescriptionSuccessedModal?.[
                             prescriptionSuccessedModal?.insuranceType + '_prescriptions'
-                        ]?.[0]?.head_EPRSC_ID}
+                        ]?.[0]?.trackingCode}
                     {prescriptionSuccessedModal?.insuranceType === 'salamat' &&
                         prescriptionSuccessedModal[
                             prescriptionSuccessedModal?.insuranceType + '_prescription'

--- a/apps/prescription/src/components/molecules/item/index.jsx
+++ b/apps/prescription/src/components/molecules/item/index.jsx
@@ -117,7 +117,9 @@ const Item = ({ dropDownShowKey, turn, refetchData, dropDownShow, setDropDownSho
                     </td>
                     <td data-label="وضعیت نسخه:">
                         {turn?.insuranceType === 'tamin' &&
-                            turn.tamin_prescription.map(item => item.head_EPRSC_ID).join(' - ')}
+                            turn.tamin_prescription
+                                .map(item => item.trackingCode ?? '')
+                                .join(' - ')}
                         {turn?.insuranceType === 'salamat' &&
                             (turn[turn?.insuranceType + '_prescription']?.trackingCode ?? '')}
                     </td>
@@ -200,7 +202,7 @@ const Item = ({ dropDownShowKey, turn, refetchData, dropDownShow, setDropDownSho
                                     <span>
                                         {turn?.insuranceType === 'tamin' &&
                                             turn.tamin_prescription
-                                                .map(item => item.head_EPRSC_ID)
+                                                .map(item => item.trackingCode)
                                                 .join(' - ')}
                                         {turn?.insuranceType === 'salamat' &&
                                             (turn.salamat_prescription?.trackingCode ?? '')}

--- a/apps/prescription/src/components/molecules/item/index.jsx
+++ b/apps/prescription/src/components/molecules/item/index.jsx
@@ -255,8 +255,8 @@ const Item = ({ dropDownShowKey, turn, refetchData, dropDownShow, setDropDownSho
                                 <span>
                                     {turn?.insuranceType === 'tamin' &&
                                         turn[turn?.insuranceType + '_prescription'].map(item => (
-                                            <span key={item.head_EPRSC_ID}>
-                                                {item.head_EPRSC_ID ?? '-'}
+                                            <span key={item.trackingCode}>
+                                                {item.trackingCode ?? '-'}
                                             </span>
                                         ))}
                                     {turn?.insuranceType === 'salamat' && (


### PR DESCRIPTION
Tamin prescriptions must use trackingCode in drug stores, so I changed head_EPRSC_ID to trackingCode which is used in prescriptions grid list and toast that shows after the successfully prescription finalized