### PR TITLE
edit the url of the page that is a guide for entering the id in eitaa

### DIFF
--- a/apps/drapp/src/components/onlineVisit/messengers.ts
+++ b/apps/drapp/src/components/onlineVisit/messengers.ts
@@ -46,7 +46,7 @@ export const messengersListData = (props: MwssengerDataParams) => {
                         name: 'راهنما',
                         type: 'text',
                         action: () =>
-                            window.open('https://community.paziresh24.com/t/topic/1055', '_blank')
+                            window.open('https://opium-dashboard.paziresh24.com/help-eitaa/', '_blank')
                     }
                 }
             ]


### PR DESCRIPTION
آدرس راهنمای ثبتِ نام کاربری ایتا از کامیونیتی به ادرس https://opium-dashboard.paziresh24.com/help-eitaa/ تغییر کرد