### PR TITLE
chore(payment): comment out legacy payment service deprecation alert

### DIFF
--- a/apps/drapp/src/pages/drApp/setting/payment/index.tsx
+++ b/apps/drapp/src/pages/drApp/setting/payment/index.tsx
@@ -88,7 +88,7 @@ const PaymentPage = () => {
                 </Alert>
             )}
 
-            {!disabled && (
+          {/*  {!disabled && (
                 <Alert icon={false} className="!bg-yellow-100 mt-3 !text-yellow-900">
                     <Typography fontSize="0.9rem" fontWeight="medium">
                         ⚠️ سرویس پرداخت فعلی تا پایان خرداد ۱۴۰۴ غیرفعال می‌شود.
@@ -111,7 +111,7 @@ const PaymentPage = () => {
                         </a>
                     </Typography>
                 </Alert>
-            )}
+            )} */}
             <Tabs
                 variant="fullWidth"
                 className="border-b border-solid border-slate-200"


### PR DESCRIPTION
**Commit Message**  
```
chore(payment): comment out legacy payment service deprecation alert
```

**Extended Description**  
- Temporarily disables the yellow warning banner that notifies users about the old payment service being shut down at the end of Khordad 1404.  
- Wrapped the entire `{!disabled && (…)}` JSX block in a JSX comment (`{/* … */}`) so that it no longer renders, without deleting the code.  
- This preserves the original markup for easy re-activation or further editing in the future.  
- No functional changes beyond hiding that alert; the rest of the payment page (tabs, settings, financial report) remains unaffected.