### PR TITLE
Enable Save button in PaymentSetting component

### DIFF
--- a/apps/drapp/src/components/payment/setting.tsx
+++ b/apps/drapp/src/components/payment/setting.tsx
@@ -150,7 +150,6 @@ export const PaymentSetting = () => {
                     variant="contained"
                     size="large"
                     loading={isLoading || ibanInquiry.isLoading}
-                    disabled={disabled}
                     onClick={() => {
                         if (
                             validate({


### PR DESCRIPTION
**Commit Message**

```
Enable Save button in PaymentSetting component
```

---

**Extended Description**

Previously, the “Save” (or “Activate”) button in the `PaymentSetting` screen was conditionally disabled based on the `disabled-finacial` feature flag. This change removes that conditional and ensures the button remains enabled at all times, regardless of feature-flag state.

* **What was changed:**

  * In `apps/drapp/src/components/payment/setting.tsx`, the `disabled={disabled}` prop on the primary `<Button>` was removed (or replaced with `disabled={false}`).
* **Why:**

  * To allow doctors to update or activate their payment settings without being blocked by the `disabled-finacial` flag, while preserving all other existing logic and UI behaviors.
* **Impact:**

  * The “Save”/“Activate” button will now always be clickable.
  * No other business logic, alerts, forms, or feature-flag-driven behaviors have been altered.
  * Downstream functionality—bank inquiry modals, Splunk events, form validation, and navigation—remains unchanged.